### PR TITLE
fix(diaries): update model, validation, service and docs for create diary

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -54,6 +54,8 @@ paths:
   /api/diaries:
     get:
       $ref: ../swagger/paths/diaries/get.yaml
+    post:
+      $ref: ../swagger/paths/diaries/post.yaml
 
   /api/diaries/{diaryId}:
     patch:

--- a/src/controllers/diaries.js
+++ b/src/controllers/diaries.js
@@ -50,7 +50,7 @@ export const getDiariesController = async (req, res, next) => {
 export const createDiaryController = async (req, res, next) => {
   const diary = await createDiary({
     ...req.body,
-    userId: req.user._id,
+    owner: req.user._id,
   });
 
   res.status(201).json({

--- a/src/db/models/diary.js
+++ b/src/db/models/diary.js
@@ -6,11 +6,13 @@ const diarySchema = new Schema(
       type: String,
       required: true,
     },
-    category: {
-      type: Schema.Types.ObjectId,
-      ref: 'emotions',
-      required: true,
-    },
+    category: [
+      {
+        type: Schema.Types.ObjectId,
+        ref: 'emotions',
+        required: true,
+      },
+    ],
     description: {
       type: String,
       required: true,

--- a/src/routers/diaries.js
+++ b/src/routers/diaries.js
@@ -20,6 +20,8 @@ const diaryRouter = Router();
 
 diaryRouter.use('/', authenticate);
 
+diaryRouter.use('/:diaryId', isValidId('diaryId'));
+
 diaryRouter.post(
   '/',
   validateBody(createDiaryValidationSchema),
@@ -31,8 +33,6 @@ diaryRouter.get(
   validateQuery(getDiariesQuerySchema),
   ctrlWrapper(getDiariesController),
 );
-
-diaryRouter.use('/:diaryId', isValidId('diaryId'));
 
 diaryRouter.patch(
   '/:diaryId',

--- a/src/services/diary.js
+++ b/src/services/diary.js
@@ -28,5 +28,5 @@ export const getDiaries = async (owner, { sortBy, order }) => {
 export const createDiary = async (payload) => {
   const diary = await DiaryModel.create(payload);
 
-  return diary;
+  return diary.populate('category');
 };

--- a/src/validation/diary.js
+++ b/src/validation/diary.js
@@ -1,7 +1,7 @@
 import Joi from 'joi';
 import {
+  categoryValidation,
   descriptionDiaryValidation,
-  objectIdValidation,
   titleDieryValidation,
 } from './helpers.js';
 
@@ -10,7 +10,7 @@ export const updateDiaryValidationSchema = Joi.object({
     'string.min': 'Title should have at least {#limit} characters',
     'string.max': 'Title should have at most {#limit} characters',
   }),
-  category: objectIdValidation(),
+  category: categoryValidation(),
   description: descriptionDiaryValidation().messages({
     'string.min': 'Description should have at least {#limit} characters',
     'string.max': 'Description should have at most {#limit} characters',
@@ -28,7 +28,7 @@ export const createDiaryValidationSchema = Joi.object({
     'string.min': 'Title should have at least {#limit} characters',
     'string.max': 'Title should have at most {#limit} characters',
   }),
-  category: objectIdValidation().required(),
+  category: categoryValidation().required(),
   description: descriptionDiaryValidation().required().messages({
     'any.required': 'Description is required',
     'string.min': 'Description should have at least {#limit} characters',

--- a/src/validation/helpers.js
+++ b/src/validation/helpers.js
@@ -29,3 +29,5 @@ export const weekPregnancyValidation = () =>
 
 export const genderValidation = () =>
   Joi.string().valid(...Object.values(GENDER));
+
+export const categoryValidation = () => Joi.array().items(objectIdValidation()).min(1);

--- a/swagger/components/schemas/diary.yaml
+++ b/swagger/components/schemas/diary.yaml
@@ -16,6 +16,8 @@ properties:
     type: string
     example: This is a test diary
   category:
-    $ref: emotion.yaml
+    type: array
+    items:
+      $ref: emotion.yaml
   userId:
     $ref: user.yaml

--- a/swagger/paths/diaries/post.yaml
+++ b/swagger/paths/diaries/post.yaml
@@ -20,8 +20,12 @@ requestBody:
             type: string
             example: My pregnancy diary
           category:
-            type: string
-            example: 64f2b5e8a9c123456789abcd
+            type: array
+            items:
+              type: string
+              example: 64f2b5e8a9c123456789abcd
+            minItems: 1
+            description: Array of emotion IDs (ObjectIds from the emotions collection). Can select multiple emotions.
           description:
             type: string
             example: Today I felt the first baby kick.
@@ -44,10 +48,33 @@ responses:
               type: string
               example: Successfully created a diary!
             data:
-              $ref: ../../../components/schemas/diary.yaml
+              type: object
+              required:
+                - _id
+                - title
+                - description
+                - category
+                - userId
+              properties:
+                _id:
+                  type: string
+                  example: 64f2b5e8a9c123456789abcd
+                title:
+                  type: string
+                  example: My first diary
+                description:
+                  type: string
+                  example: This is a test diary
+                category:
+                  type: array
+                  items:
+                    $ref: ../../components/schemas/emotion.yaml
+                userId:
+                  type: string
+                  example: 64f2b5e8a9c123456789abcd
   '400':
-    $ref: '../../../components/responses/400.yaml'
+    $ref: '../../components/responses/400.yaml'
   '401':
-    $ref: '../../../components/responses/401.yaml'
+    $ref: '../../components/responses/401.yaml'
   '500':
-    $ref: '../../../components/responses/500.yaml'
+    $ref: '../../components/responses/500.yaml'


### PR DESCRIPTION
- Changed 'category' in Diary model from ObjectId to an array of ObjectIds to allow multiple emotions per diary.
- Updated service to populate 'category' so API responses return full emotion objects.
- Refactored validation: changed 'category' from string to array and added new function for array validation.
- Renamed 'userId' to 'owner' across model, controller, and service to match API paths.
- Updated OpenAPI documentation for POST /diaries to reflect these changes.