### PR TITLE
fix(tasks): correct toggle status flow and remove redundant validation

### DIFF
--- a/src/controllers/tasks.js
+++ b/src/controllers/tasks.js
@@ -31,15 +31,11 @@ export const getAllTasksController = async (req, res, next) => {
 
 export const updateTaskStatusController = async (req, res, next) => {
   const { taskId } = req.params;
-  const owner = req.user._id;
-  const task = await updateTaskStatus(taskId, owner);
 
-  if (!task) {
-    return res.status(404).json({
-      status: 404,
-      message: 'Task not found',
-    });
-  }
+  const owner = req.user._id;
+  if (!owner) throw httpError(401, 'Unauthorized');
+
+  const task = await updateTaskStatus(taskId, owner);
 
   res.status(200).json({
     status: 200,

--- a/src/routers/tasks.js
+++ b/src/routers/tasks.js
@@ -6,7 +6,6 @@ import { validateBody } from '../middlewares/validateBody.js';
 import {
   createTaskValidationSchema,
   getAllTasksValidationSchema,
-  updateTaskValidationSchema,
 } from '../validation/task.js';
 import { ctrlWrapper } from '../utils/ctrlWrapper.js';
 import {
@@ -35,7 +34,6 @@ taskRouter.get(
 
 taskRouter.patch(
   '/:taskId/status',
-  validateBody(updateTaskValidationSchema),
   ctrlWrapper(updateTaskStatusController),
 );
 

--- a/src/services/task.js
+++ b/src/services/task.js
@@ -1,3 +1,4 @@
+import createHttpError from 'http-errors';
 import { TaskModel } from '../db/models/task.js';
 
 export const createTask = async (payload) => {
@@ -15,8 +16,14 @@ export const getAllTasks = async ({ owner, isDone, order = 'asc' }) => {
   return tasks;
 };
 
-export const updateTaskStatus = async (taskId, owner, isDone) => {
+export const updateTaskStatus = async (taskId, owner) => {
   const task = await TaskModel.findOne({ _id: taskId, owner });
+
+  if (!task)
+    throw createHttpError(
+      404,
+      'Not found task!',
+    );
 
   task.isDone = !task.isDone;
 

--- a/src/validation/task.js
+++ b/src/validation/task.js
@@ -26,8 +26,3 @@ export const getAllTasksValidationSchema = Joi.object({
   order: Joi.string().valid('asc', 'desc').default('asc'),
 });
 
-export const updateTaskValidationSchema = Joi.object({
-  isDone: isDoneValidation()
-    .required()
-    .messages({ 'any.required': 'isDone is a required field' }),
-});

--- a/swagger/paths/tasks/{taskId}/status/patch.yaml
+++ b/swagger/paths/tasks/{taskId}/status/patch.yaml
@@ -15,15 +15,6 @@ parameters:
       type: string
       example: '650f7f5d4a1c2b00123abcd1'
 
-requestBody:
-  description: Optional request body (can be empty)
-  required: false
-  content:
-    application/json:
-      schema:
-        type: object
-        example: {}
-
 responses:
   '200':
     description: Task status updated successfully


### PR DESCRIPTION
- added 401 Unauthorized check in controller if user is missing
- updated service to throw 404 Not Found instead of causing 500 when task is absent
- removed body validation for isDone since toggle does not require request body
- cleaned up OpenAPI spec: requestBody removed, only path param taskId left

This fixes the issue where toggling a task status could crash the server
with a 500 error. Now responses are consistent: 401, 404, or 200.