### PR TITLE
fix: calculate fixed 5th week for public week data

### DIFF
--- a/src/services/week.js
+++ b/src/services/week.js
@@ -31,13 +31,12 @@ export const getWeeksMomStates = async (weekNumber) => {
 
 export const getPublicWeekData = async () => {
   const today = new Date();
-  const fiveWeeksLater = new Date(today);
-  fiveWeeksLater.setDate(today.getDate() + 7 * 37);
-
-  const publicWeek = calculateCurrentWeek(
-    { dueDate: fiveWeeksLater },
-    undefined,
+    const fiveWeeksLater = new Date(
+    today.getTime() + 7 * 5 * 24 * 60 * 60 * 1000,
   );
+
+  const diffInMs = fiveWeeksLater.getTime() - today.getTime();
+  const publicWeek = Math.ceil(diffInMs / (1000 * 60 * 60 * 24 * 7));
 
   const weekData = await BabyStatesModel.find({
     weekNumber: publicWeek,
@@ -48,7 +47,7 @@ export const getPublicWeekData = async () => {
   }
 
   return {
-    ...weekData,
+    data: weekData[0] || null,
     currentWeek: publicWeek,
     isPersonalized: false,
   };


### PR DESCRIPTION
 Replaced previous date calculation logic with a fixed 5-week offset from today.
- Ensures consistent week data is shown for public access regardless of the current date.
- Returns the corresponding week data from the database with `currentWeek` set to 5 and `isPersonalized` as false.