### PR TITLE
feat(auth): add session check endpoint and Swagger docs

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -53,6 +53,10 @@ paths:
     post:
       $ref: ../swagger/paths/auth/logout.yaml
 
+  /api/auth/session:
+    get:
+      $ref: ../swagger/paths/auth/session.yaml
+
   /api/diaries:
     get:
       $ref: ../swagger/paths/diaries/get.yaml

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -580,6 +580,58 @@
         }
       }
     },
+    "/api/auth/session": {
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Check user session",
+        "operationId": "checkSession",
+        "description": "Checks if the user is currently authenticated. Returns true if the session is valid, false otherwise.",
+        "security": [],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "Bearer <accessToken>"
+            },
+            "description": "Bearer token of the current session"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns whether the user is authenticated.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "status",
+                    "data"
+                  ],
+                  "properties": {
+                    "status": {
+                      "type": "integer",
+                      "example": 200
+                    },
+                    "data": {
+                      "type": "boolean",
+                      "example": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          }
+        }
+      }
+    },
     "/api/diaries": {
       "get": {
         "tags": [

--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -4,6 +4,7 @@ import {
   refreshUserSession,
   registerUser,
   logoutUser,
+  checkSession,
 } from '../services/auth.js';
 
 export const registerUserController = async (req, res) => {
@@ -52,4 +53,18 @@ export const logoutUserController = async (req, res) => {
   res.clearCookie('refreshToken');
 
   res.status(204).send();
+};
+
+export const checkSessionController =async (req, res) => {
+
+  const authHeader = req.get('Authorization');
+  const token = authHeader?.split(' ')[1];
+
+  const session = await checkSession(token);
+
+  res.json({
+    status: 200,
+    data: !!session,
+  });
+
 };

--- a/src/routers/auth.js
+++ b/src/routers/auth.js
@@ -10,10 +10,13 @@ import {
   refreshUserSessionController,
   registerUserController,
   logoutUserController,
+  checkSessionController,
 } from '../controllers/auth.js';
 import { ctrlWrapper } from '../utils/ctrlWrapper.js';
 
 const authRouter = Router();
+
+authRouter.get('/session', ctrlWrapper(checkSessionController));
 
 authRouter.post(
   '/register',
@@ -28,7 +31,6 @@ authRouter.post(
 );
 
 authRouter.post('/refresh', ctrlWrapper(refreshUserSessionController));
-
 
 authRouter.post('/logout', authenticate, ctrlWrapper(logoutUserController));
 

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -50,7 +50,6 @@ export const refreshUserSession = async (sessionId, refreshToken) => {
   return newSession;
 };
 
-
 export const logoutUser = async (sessionId) => {
   await SessionModel.deleteOne({ _id: sessionId });
 };
@@ -66,4 +65,15 @@ export const loginUser = async (payload) => {
   await SessionModel.deleteOne({ userId: user._id });
 
   return SessionModel.create(createSession(user._id));
+};
+
+export const checkSession = async (token) => {
+  if (!token) return null;
+
+  const session = await SessionModel.findOne({
+    accessToken: token,
+    accessTokenValidUntil: { $gt: new Date() },
+  }).lean();
+
+  return session;
 };

--- a/swagger/paths/auth/session.yaml
+++ b/swagger/paths/auth/session.yaml
@@ -1,0 +1,34 @@
+tags:
+  - Auth
+summary: Check user session
+operationId: checkSession
+description: 'Checks if the user is currently authenticated. Returns true if the session is valid, false otherwise.'
+security: []
+parameters:
+  - in: header
+    name: Authorization
+    required: false
+    schema:
+      type: string
+      example: 'Bearer <accessToken>'
+    description: 'Bearer token of the current session'
+
+responses:
+  '200':
+    description: 'Returns whether the user is authenticated.'
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - status
+            - data
+          properties:
+            status:
+              type: integer
+              example: 200
+            data:
+              type: boolean
+              example: true
+  '401':
+    $ref: '../../components/responses/401.yaml'


### PR DESCRIPTION
- Added a new GET endpoint `/api/auth/session` to check if the user is authenticated.
- `checkSessionController` checks for a valid session by token and returns `true` or `false`.
- Created `checkSession` service to handle session verification in the database.
- Updated Swagger documentation with Authorization header and response schema.
- Purpose: frontend can use this endpoint via AuthProvider to determine user authentication status.