### PR TITLE
feat: add getDiaryById endpoint with controller, service, and docs

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -64,6 +64,8 @@ paths:
       $ref: ../swagger/paths/diaries/{diaryId}/patch.yaml
     delete:
       $ref: ../swagger/paths/diaries/{diaryId}/delete.yaml
+    get:
+      $ref: ../swagger/paths/diaries/{diaryId}/get.yaml
 
   /api/tasks:
     get:

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -117,7 +117,7 @@
                   "properties": {
                     "status": {
                       "type": "string",
-                      "example": "success"
+                      "example": 200
                     },
                     "message": {
                       "type": "string",
@@ -890,6 +890,70 @@
           },
           "403": {
             "$ref": "#/components/responses/403"
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Diaries"
+        ],
+        "summary": "Get diary by id",
+        "operationId": "getDiaryById",
+        "description": "Retrieves a diary by its ID. Only the owner can access their diary.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "diaryId",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "65ca67e7ae7f10c88b598384"
+            },
+            "description": "ID of the diary to retrieve"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the diary.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "status",
+                    "message",
+                    "data"
+                  ],
+                  "properties": {
+                    "status": {
+                      "type": "integer",
+                      "example": 200
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Successfully found a diary!"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/diary"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
           }
         }
       }

--- a/src/controllers/diaries.js
+++ b/src/controllers/diaries.js
@@ -4,6 +4,7 @@ import {
   updateDiaryById,
   getDiaries,
   createDiary,
+  getDiaryById,
 } from '../services/diary.js';
 
 export const updateDiaryByIdController = async (req, res, next) => {
@@ -25,6 +26,22 @@ export const updateDiaryByIdController = async (req, res, next) => {
   });
 };
 
+
+export const getDiaryByIdController = async (req, res, next) => {
+  const { diaryId } = req.params;
+  const owner = req.user._id;
+
+  const diary = await getDiaryById(diaryId, owner);
+
+  if (!diary) throw createHttpError(404, "Diary not found");
+
+  res.json({
+    status: 200,
+    message: 'Successfully found a diary!',
+    data: diary,
+  });
+};
+
 export const deleteDiaryByIdController = async (req, res, next) => {
   const { diaryId } = req.params;
   const owner = req.user._id;
@@ -35,7 +52,7 @@ export const deleteDiaryByIdController = async (req, res, next) => {
       403,
       'You do not have permission to access this diary',
     );
-  
+
   res.status(204).send();
 };
 

--- a/src/routers/diaries.js
+++ b/src/routers/diaries.js
@@ -6,6 +6,7 @@ import {
   updateDiaryByIdController,
   getDiariesController,
   createDiaryController,
+  getDiaryByIdController,
 } from '../controllers/diaries.js';
 import { validateBody } from '../middlewares/validateBody.js';
 import {
@@ -21,6 +22,8 @@ const diaryRouter = Router();
 diaryRouter.use('/', authenticate);
 
 diaryRouter.use('/:diaryId', isValidId('diaryId'));
+
+diaryRouter.get('/:diaryId', ctrlWrapper(getDiaryByIdController));
 
 diaryRouter.post(
   '/',

--- a/src/services/diary.js
+++ b/src/services/diary.js
@@ -13,6 +13,15 @@ export const updateDiaryById = async (diaryId, userId, payload) => {
   return diary;
 };
 
+export const getDiaryById = async (diaryId, userId) => {
+  const diary = await DiaryModel.findOne({
+    _id: diaryId,
+    owner: userId,
+  }).populate('category');
+
+  return diary;
+};
+
 export const deleteDiaryById = async (diaryId, owner) => {
   const diary = await DiaryModel.findOneAndDelete({
     _id: diaryId,

--- a/swagger/paths/diaries/{diaryId}/get.yaml
+++ b/swagger/paths/diaries/{diaryId}/get.yaml
@@ -1,0 +1,41 @@
+tags:
+  - Diaries
+summary: Get diary by id
+operationId: getDiaryById
+description: 'Retrieves a diary by its ID. Only the owner can access their diary.'
+security:
+  - bearerAuth: []
+parameters:
+  - in: path
+    name: diaryId
+    required: true
+    schema:
+      type: string
+      example: '65ca67e7ae7f10c88b598384'
+    description: 'ID of the diary to retrieve'
+responses:
+  '200':
+    description: 'Successfully retrieved the diary.'
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - status
+            - message
+            - data
+          properties:
+            status:
+              type: integer
+              example: 200
+            message:
+              type: string
+              example: 'Successfully found a diary!'
+            data:
+             $ref: ../../../components/schemas/diary.yaml
+  '401':
+    $ref: '../../../components/responses/401.yaml'
+  '400':
+    $ref: '../../../components/responses/400.yaml'
+  '404':
+    $ref: '../../../components/responses/404.yaml'

--- a/swagger/paths/users/get.yaml
+++ b/swagger/paths/users/get.yaml
@@ -15,7 +15,7 @@ responses:
           properties:
             status:
               type: string
-              example: success
+              example: 200
             message:
               type: string
               example: User retrieved successfully


### PR DESCRIPTION
- Created `getDiaryByIdController` to handle retrieving a diary by ID.
- Implemented `getDiaryById` service function to fetch diary from the database and populate its category.
- Added GET route `/diaries/:diaryId` in `diaryRouter`.
- Added OpenAPI/Swagger documentation for this endpoint.
- Ensures only the owner of the diary can access it.