### PR TITLE
Viacheslav

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -382,7 +382,7 @@
         ],
         "summary": "Login user",
         "operationId": "loginUser",
-        "description": "Login user",
+        "description": "Login user. Sets tokens in httpOnly cookies.",
         "security": [],
         "requestBody": {
           "required": true,
@@ -412,15 +412,29 @@
         },
         "responses": {
           "200": {
-            "description": "Successfully login a user!",
+            "description": "Successfully logged in. Tokens are set in cookies.",
+            "headers": {
+              "Set-Cookie": {
+                "description": "Cookies set after successful login.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "example": [
+                      "refreshToken=eyJ...; Path=/; HttpOnly; Secure; SameSite=Lax",
+                      "accessToken=eyJ...; Path=/; HttpOnly; Secure; SameSite=Lax"
+                    ]
+                  }
+                }
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
                   "required": [
                     "status",
-                    "message",
-                    "data"
+                    "message"
                   ],
                   "properties": {
                     "status": {
@@ -429,16 +443,7 @@
                     },
                     "message": {
                       "type": "string",
-                      "example": "Successfully login a user!"
-                    },
-                    "data": {
-                      "type": "object",
-                      "properties": {
-                        "accessToken": {
-                          "type": "string",
-                          "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2NDNkZmY1ZmQ4NTY0ZGI2ZjU3NzFlNmMiLCJpYXQiOjE2OTU1ODU0MDAsImV4cCI6MTY5NTU4NjMwMH0.vW3Xg3w-ExampleJWT"
-                        }
-                      }
+                      "example": "Successfully logged in"
                     }
                   }
                 }
@@ -461,7 +466,7 @@
         ],
         "summary": "Refresh user session",
         "operationId": "refreshSession",
-        "description": "Refreshes an existing session using a refresh token. Returns a new access token.",
+        "description": "Refreshes an existing session using a refresh token. Sets new cookies with updated tokens.",
         "security": [],
         "parameters": [
           {
@@ -477,17 +482,17 @@
         ],
         "responses": {
           "200": {
-            "description": "Successfully refreshed a session!",
+            "description": "Successfully refreshed a session! Tokens are set in cookies.",
             "headers": {
               "Set-Cookie": {
-                "description": "Cookies set after successful login.",
+                "description": "Cookies set after successful refresh.",
                 "schema": {
                   "type": "array",
                   "items": {
                     "type": "string",
                     "example": [
-                      "session_id=test321; Path=/; HttpOnly;",
-                      "refresh_token=get471; Path=/; HttpOnly;"
+                      "refreshToken=eyJ...; Path=/; HttpOnly; Secure; SameSite=Lax",
+                      "accessToken=eyJ...; Path=/; HttpOnly; Secure; SameSite=Lax"
                     ]
                   }
                 }
@@ -499,8 +504,7 @@
                   "type": "object",
                   "required": [
                     "status",
-                    "message",
-                    "data"
+                    "message"
                   ],
                   "properties": {
                     "status": {
@@ -510,15 +514,6 @@
                     "message": {
                       "type": "string",
                       "example": "Successfully refreshed a session!"
-                    },
-                    "data": {
-                      "type": "object",
-                      "properties": {
-                        "accessToken": {
-                          "type": "string",
-                          "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2NDNkZmY1ZmQ4NTY0ZGI2ZjU3NzFlNmMiLCJpYXQiOjE2OTU1ODU0MDAsImV4cCI6MTY5NTU4NjMwMH0.vW3Xg3w-ExampleJWT"
-                        }
-                      }
                     }
                   }
                 }

--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -26,9 +26,6 @@ export const loginUserController = async (req, res) => {
   res.json({
     status: 200,
     message: 'Successfully logged in an user!',
-    data: {
-      accessToken: session.accessToken,
-    },
   });
 };
 
@@ -40,18 +37,30 @@ export const refreshUserSessionController = async (req, res) => {
   res.json({
     status: 200,
     message: 'Successfully refreshed a session!',
-    data: { accessToken: session.accessToken },
   });
 };
 
 export const logoutUserController = async (req, res) => {
-  if (req.cookies.refreshToken) await logoutUser(req.cookies.refreshToken);
+ const { refreshToken, accessToken } = req.cookies;
 
-  res.clearCookie('refreshToken', {
-    httpOnly: true,
-    secure: process.env.NODE_ENV === 'production',
-    sameSite: 'strict',
-  });
+ if (refreshToken) {
+   await logoutUser(refreshToken);
+ }
+ res.clearCookie('refreshToken', {
+   httpOnly: true,
+   secure: process.env.NODE_ENV === 'production',
+   sameSite: 'lax',
+   path: '/',
+ });
+
+ if (accessToken) {
+   res.clearCookie('accessToken', {
+     httpOnly: true,
+     secure: process.env.NODE_ENV === 'production',
+     sameSite: 'lax',
+     path: '/',
+   });
+ }
 
   res.status(204).send();
 };

--- a/src/helpers/auth.js
+++ b/src/helpers/auth.js
@@ -32,4 +32,15 @@ export const setupSession = (res, session) => {
     path: '/',
     maxAge: Math.floor((session.refreshTokenValidUntil.getTime() - Date.now()) / 1000),
   });
+
+  res.cookie('accessToken', session.accessToken, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    expires: session.accessTokenValidUntil,
+    path: '/',
+    maxAge: Math.floor(
+      (session.accessTokenValidUntil.getTime() - Date.now()) / 1000,
+    ),
+  });
 };

--- a/swagger/paths/auth/login.yaml
+++ b/swagger/paths/auth/login.yaml
@@ -2,7 +2,7 @@ tags:
   - Auth
 summary: Login user
 operationId: loginUser
-description: 'Login user'
+description: 'Login user. Sets tokens in httpOnly cookies.'
 security: []
 requestBody:
   required: true
@@ -24,7 +24,17 @@ requestBody:
             example: 'vldfmvvdfjgdfg'
 responses:
   '200':
-    description: Successfully login a user!
+    description: Successfully logged in. Tokens are set in cookies.
+    headers:
+      Set-Cookie:
+        description: Cookies set after successful login.
+        schema:
+          type: array
+          items:
+            type: string
+            example:
+              - refreshToken=eyJ...; Path=/; HttpOnly; Secure; SameSite=Lax
+              - accessToken=eyJ...; Path=/; HttpOnly; Secure; SameSite=Lax
     content:
       application/json:
         schema:
@@ -32,20 +42,14 @@ responses:
           required:
             - status
             - message
-            - data
           properties:
             status:
               type: integer
               example: 200
             message:
               type: string
-              example: Successfully login a user!
-            data:
-              type: object
-              properties:
-                accessToken:
-                  type: string
-                  example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2NDNkZmY1ZmQ4NTY0ZGI2ZjU3NzFlNmMiLCJpYXQiOjE2OTU1ODU0MDAsImV4cCI6MTY5NTU4NjMwMH0.vW3Xg3w-ExampleJWT'
+              example: Successfully logged in
+
   '400':
     $ref: '../../components/responses/400.yaml'
   '401':

--- a/swagger/paths/auth/refresh.yaml
+++ b/swagger/paths/auth/refresh.yaml
@@ -2,7 +2,7 @@ tags:
   - Auth
 summary: Refresh user session
 operationId: refreshSession
-description: 'Refreshes an existing session using a refresh token. Returns a new access token.'
+description: 'Refreshes an existing session using a refresh token. Sets new cookies with updated tokens.'
 security: []
 parameters:
   - in: cookie
@@ -15,17 +15,17 @@ parameters:
 
 responses:
   '200':
-    description: 'Successfully refreshed a session!'
+    description: 'Successfully refreshed a session! Tokens are set in cookies.'
     headers:
       Set-Cookie:
-        description: Cookies set after successful login.
+        description: Cookies set after successful refresh.
         schema:
           type: array
           items:
             type: string
             example:
-              - session_id=test321; Path=/; HttpOnly;
-              - refresh_token=get471; Path=/; HttpOnly;
+              - refreshToken=eyJ...; Path=/; HttpOnly; Secure; SameSite=Lax
+              - accessToken=eyJ...; Path=/; HttpOnly; Secure; SameSite=Lax
     content:
       application/json:
         schema:
@@ -33,7 +33,6 @@ responses:
           required:
             - status
             - message
-            - data
           properties:
             status:
               type: integer
@@ -41,12 +40,6 @@ responses:
             message:
               type: string
               example: 'Successfully refreshed a session!'
-            data:
-              type: object
-              properties:
-                accessToken:
-                  type: string
-                  example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2NDNkZmY1ZmQ4NTY0ZGI2ZjU3NzFlNmMiLCJpYXQiOjE2OTU1ODU0MDAsImV4cCI6MTY5NTU4NjMwMH0.vW3Xg3w-ExampleJWT
 
   '401':
     $ref: '../../components/responses/401.yaml'


### PR DESCRIPTION
Removed accessToken from API responses for login, registration, and refresh endpoints.  
Now both access and refresh tokens are stored and sent via secure HTTP-only cookies.  
Middleware uses cookies to authenticate requests to private routes.  
This improves security and simplifies frontend token handling.